### PR TITLE
fix(seo): use www.filmguess.com as canonical to match live domain

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,9 @@
       "Bash(git commit -m ' *)",
       "Bash(npx next *)",
       "Bash(node_modules/.bin/next lint *)",
-      "Bash(node_modules/.bin/eslint src *)"
+      "Bash(node_modules/.bin/eslint src *)",
+      "Bash(curl -sI https://filmguess.com/)",
+      "Bash(curl -sI https://www.filmguess.com/)"
     ]
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,4 +4,4 @@ Disallow: /addMedia
 Disallow: /addPosts
 Disallow: /api/
 
-Sitemap: https://filmguess.com/sitemap.xml
+Sitemap: https://www.filmguess.com/sitemap.xml

--- a/src/components/custom/Misc/InfoPageLayout.tsx
+++ b/src/components/custom/Misc/InfoPageLayout.tsx
@@ -124,7 +124,7 @@ function toBreadcrumbLabel(segment: string) {
 export function InfoPageLayout({ children }: InfoPageLayoutProps) {
   const router = useRouter();
   const path = router.asPath.split("?")[0].split("#")[0];
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://filmguess.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.filmguess.com";
 
   const breadcrumbItems = useMemo(() => {
     const segments = path.split("/").filter(Boolean);

--- a/src/components/custom/Misc/SEO.tsx
+++ b/src/components/custom/Misc/SEO.tsx
@@ -19,7 +19,7 @@ export function SEO({
   canonicalUrl,
   noIndex = false,
 }: SEOProps) {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://filmguess.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.filmguess.com";
   const fullTitle = title.includes("Filmguess") ? title : `${title} | Filmguess`;
   const canonical = canonicalUrl
     ? canonicalUrl === "/"

--- a/src/components/custom/Pages/articles/ranking-0001.jsx
+++ b/src/components/custom/Pages/articles/ranking-0001.jsx
@@ -16,7 +16,7 @@ export default function TopMovieQuotesArticle() {
       <p>
         A Fazer!
       </p>
-      <p><a href="https://filmguess.com/content">Play the Game!</a></p>
+      <p><a href="/content">Play the Game!</a></p>
     </section>
 
     </>

--- a/src/components/custom/Pages/articles/top-20-action-movies-quotes.jsx
+++ b/src/components/custom/Pages/articles/top-20-action-movies-quotes.jsx
@@ -9,7 +9,7 @@ export default function TopMovieQuotesArticle() {
     The best action movie quotes usually happen in the craziest moments — when the hero is fighting the villain and it’s basically life or death.
     Think of scenes like <cite>Arnold Schwarzenegger</cite> facing the T-1000 in the steel mill in
     <cite>Terminator 2: Judgment Day</cite>, <cite>John McClane</cite> crawling through the vents in <cite>Die Hard</cite>,
-    or <cite>Keanu Reeves</cite> as <cite>John Wick</cite>. That’s the kind of moment we try to pick for <a href="https://filmguess.com/content">FilmGuess</a> — though sometimes the fun part is when the quote isn’t that obvious.
+    or <cite>Keanu Reeves</cite> as <cite>John Wick</cite>. That’s the kind of moment we try to pick for <a href="/content">FilmGuess</a> — though sometimes the fun part is when the quote isn’t that obvious.
     </p>
     
     <section aria-labelledby="top-20-action">
@@ -45,7 +45,7 @@ export default function TopMovieQuotesArticle() {
         Think you know action cinema? Try our audio quiz and guess the movie from a short sound clip.
         Each question includes four options and a curated excerpt.
       </p>
-      <p><a href="https://filmguess.com/content">Play the Game!</a></p>
+      <p><a href="/content">Play the Game!</a></p>
     </section>
 
     </>

--- a/src/components/custom/Pages/articles/top-20-comedy-movies-quotes.jsx
+++ b/src/components/custom/Pages/articles/top-20-comedy-movies-quotes.jsx
@@ -44,7 +44,7 @@ export default function TopMovieQuotesArticle() {
         Think you know comedy cinema? Try our audio quiz and guess the movie from a short sound clip.
         Each question includes four options and a curated excerpt.
       </p>
-      <p><a href="https://filmguess.com/content">Play the game!</a></p>
+      <p><a href="/content">Play the game!</a></p>
     </section>
 
     </>

--- a/src/components/custom/Pages/articles/top-20-modern-comedy-movies-quotes.jsx
+++ b/src/components/custom/Pages/articles/top-20-modern-comedy-movies-quotes.jsx
@@ -44,7 +44,7 @@ export default function TopMovieQuotesArticle() {
         Think you know comedy cinema? Try our audio quiz and guess the movie from a short sound clip.
         Each question includes four options and a curated excerpt.
       </p>
-      <p><a href="https://filmguess.com/content">Play the game!</a></p>
+      <p><a href="/content">Play the game!</a></p>
     </section>
 
     </>

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -133,7 +133,7 @@ export default function BlogArticlePage({
 
   const readingTime = estimateReadingTime(currentPost.html);
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://filmguess.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.filmguess.com";
   const postUrl = `${siteUrl}/blog/${currentPost.slug}`;
   const blogPostingJsonLd = {
     "@context": "https://schema.org",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ import { FlexC } from "@/components/containers/flex";
 import Head from "next/head";
 export { getServerSideProps } from "@/lib/context/getServerSideProps";
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://filmguess.com";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.filmguess.com";
 
 const homeJsonLd = {
   "@context": "https://schema.org",

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -36,7 +36,7 @@ ${urls}
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://filmguess.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.filmguess.com";
 
   const staticEntries: SitemapEntry[] = [
     { loc: buildAbsoluteUrl(siteUrl, "/"), changefreq: "daily", priority: 1.0 },


### PR DESCRIPTION
Apex filmguess.com 307-redirects to www.filmguess.com, but canonical/OG URLs pointed at the apex. Google saw the canonical target redirect and flagged the home page "Page with redirect", refusing to index it.

- Default siteUrl fallback -> https://www.filmguess.com (SEO, sitemap, index, blog/[slug], InfoPageLayout)
- robots.txt sitemap URL -> www
- article CTA links -> relative /content (avoid redirect hop)